### PR TITLE
[codex] Fix Vite Dependabot advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14042,9 +14042,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",


### PR DESCRIPTION
## Summary
- Updates the locked transitive Vite dependency from 6.4.1 to 6.4.3.
- Addresses GHSA-p9ff-h696-f583 / CVE-2026-39363, where patched Vite 6.x starts at 6.4.2.

## Validation
- npm ci
- npm run build
- npm audit report no longer includes a Vite vulnerability for this advisory.